### PR TITLE
Add responsive dashboard layout

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import DashboardShell from "../components/DashboardShell";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        {children}
+        <DashboardShell>{children}</DashboardShell>
       </body>
     </html>
   );

--- a/frontend/src/components/DashboardShell.tsx
+++ b/frontend/src/components/DashboardShell.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import Sidebar from "./Sidebar";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+
+export default function DashboardShell({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+
+  const handleLogout = () => {
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("token");
+    }
+    router.push("/login");
+  };
+
+  const noSidebar = pathname === "/login";
+
+  if (noSidebar) return <>{children}</>;
+
+  return (
+    <div className="flex min-h-screen bg-background text-foreground">
+      {/* Static sidebar for desktop */}
+      <aside className="hidden md:flex">
+        <Sidebar activePath={pathname} isAdmin onLogout={handleLogout} />
+      </aside>
+
+      {/* Drawer sidebar for mobile */}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="p-0 bg-sidebar text-sidebar-foreground max-w-xs w-64">
+          <Sidebar
+            activePath={pathname}
+            isAdmin
+            onLogout={handleLogout}
+            closeDrawer={() => setOpen(false)}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="md:hidden p-2">
+          <button
+            onClick={() => setOpen(true)}
+            className="p-2 rounded bg-gray-900 text-white"
+            aria-label="Open navigation"
+          >
+            ☰
+          </button>
+        </div>
+        <main className="flex-1 overflow-y-auto p-4">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,42 +1,110 @@
 "use client";
 import Link from "next/link";
+import {
+  Home,
+  Image as ImageIcon,
+  Database,
+  CalendarClock,
+  ListChecks,
+  Settings,
+  FlaskConical,
+  LogOut,
+} from "lucide-react";
 import ThemeToggle from "./ThemeToggle";
 import SettingsDrawer from "./SettingsDrawer";
+import { cn } from "@/lib/utils";
 
-function NavItem({ icon, label, href, active, onClick }: { icon: string; label: string; href: string; active?: boolean; onClick?: () => void }) {
+type NavItemProps = {
+  href: string;
+  label: string;
+  icon: React.ElementType;
+  active?: boolean;
+  onClick?: () => void;
+};
+
+function NavItem({ href, label, icon: Icon, active, onClick }: NavItemProps) {
   return (
     <Link
       href={href}
       onClick={onClick}
-      className={`flex items-center gap-3 px-3 py-2 rounded transition-colors font-medium text-white hover:bg-gray-800 ${active ? "bg-gray-800" : ""}`}
+      className={cn(
+        "flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium",
+        active
+          ? "bg-sidebar-primary text-sidebar-primary-foreground"
+          : "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+      )}
     >
-      <span className="text-lg">{icon}</span>
+      <Icon className="size-4" />
       <span>{label}</span>
     </Link>
   );
 }
 
-export default function Sidebar({ activePath, isAdmin, onLogout, closeDrawer }: { activePath: string; isAdmin: boolean; onLogout: () => void; closeDrawer?: () => void }) {
+export default function Sidebar({
+  activePath,
+  isAdmin,
+  onLogout,
+  closeDrawer,
+}: {
+  activePath: string;
+  isAdmin: boolean;
+  onLogout: () => void;
+  closeDrawer?: () => void;
+}) {
+  const links = [
+    { href: "/", label: "Dashboard", icon: Home },
+    { href: "/media", label: "Media", icon: ImageIcon },
+    { href: "/data", label: "Data", icon: Database },
+    { href: "/scheduler", label: "Scheduler", icon: CalendarClock },
+    { href: "/tasks", label: "Tasks", icon: ListChecks },
+    { href: "/settings", label: "Settings", icon: Settings },
+  ];
+
+  const adminLinks = [
+    { href: "/admin", label: "Admin", icon: FlaskConical },
+  ];
+
   return (
-    <div className="flex flex-col h-full w-full min-w-[220px] bg-gray-900 p-4">
-      <div className="mb-8 flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-white tracking-tight mb-2">SchedulerX</h1>
+    <div className="flex flex-col h-full w-full min-w-[220px] bg-sidebar text-sidebar-foreground border-r border-sidebar-border">
+      <div className="px-4 py-3 flex items-center justify-between border-b border-sidebar-border">
+        <h1 className="text-lg font-semibold tracking-tight">SchedulerX</h1>
         <ThemeToggle />
       </div>
-      <nav className="flex flex-col gap-1 flex-1">
-        <NavItem icon="📂" label="Media" href="/media" active={activePath.startsWith("/media")} onClick={closeDrawer} />
-        <NavItem icon="🗓️" label="Scheduler" href="/scheduler" active={activePath.startsWith("/scheduler")} onClick={closeDrawer} />
-        <NavItem icon="⚙️" label="Pipeline" href="/pipeline" active={activePath.startsWith("/pipeline")} onClick={closeDrawer} />
-        <NavItem icon="📊" label="Logs" href="/analytics" active={activePath.startsWith("/analytics")} onClick={closeDrawer} />
-        <hr className="my-3 border-gray-700" />
-        <NavItem icon="👤" label="Account" href="/account" active={activePath.startsWith("/account")} onClick={closeDrawer} />
-        {isAdmin && <NavItem icon="🧪" label="Dev Tools" href="/tools" active={activePath.startsWith("/tools")} onClick={closeDrawer} />}
-        <hr className="my-3 border-gray-700" />
+      <nav className="flex flex-col flex-1 gap-1 p-2">
+        {links.map((l) => (
+          <NavItem
+            key={l.href}
+            href={l.href}
+            label={l.label}
+            icon={l.icon}
+            active={activePath === l.href || activePath.startsWith(l.href + "/")}
+            onClick={closeDrawer}
+          />
+        ))}
+        {isAdmin && (
+          <>
+            <hr className="my-3 border-sidebar-border" />
+            {adminLinks.map((l) => (
+              <NavItem
+                key={l.href}
+                href={l.href}
+                label={l.label}
+                icon={l.icon}
+                active={activePath.startsWith(l.href)}
+                onClick={closeDrawer}
+              />
+            ))}
+          </>
+        )}
+        <hr className="my-3 border-sidebar-border" />
         <button
-          onClick={() => { onLogout(); if (closeDrawer) closeDrawer(); }}
-          className="flex items-center gap-3 px-3 py-2 rounded hover:bg-gray-800 transition-colors text-white font-medium"
+          onClick={() => {
+            onLogout();
+            if (closeDrawer) closeDrawer();
+          }}
+          className="flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
         >
-          <span className="text-lg">🚪</span>
+          <LogOut className="size-4" />
           <span>Logout</span>
         </button>
         <SettingsDrawer triggerClass="mt-2" />


### PR DESCRIPTION
## Summary
- implement `DashboardShell` with Sidebar and mobile drawer
- wrap app pages with `DashboardShell` via root layout
- rebuild Sidebar component with modern navigation links

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842dace898883219217b9a1d30a9f13